### PR TITLE
Store checksums of previously uploaded parts when resuming uploads

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,6 +124,7 @@ def main():
             if checksum == sha256_treehash:
                 print('Checksum match. Removing from job list.')
                 job_list.remove(byte_start)
+                list_of_checksums[part_num] = checksum
             else:
                 print('Checksum mismatch. Not removing.')
 


### PR DESCRIPTION
When uploads are being resumed, we need to keep track of the checksums
of previously uploaded parts so we can calculate the final checksum.