### PR TITLE
Fix console scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
             'init_inventory_retrieval=glacier_upload.initiate_job:init_inventory_retrieval',
             'get_glacier_job_output=glacier_upload.get_job_output:get_job_output',
             'abort_glacier_upload=glacier_upload.abort_upload:abort_upload',
-            'delete_glacier_archive=glacier_upload.delete_archive.delete_archive'
+            'delete_glacier_archive=glacier_upload.delete_archive:delete_archive'
         ],
     },
 )

--- a/src/glacier_upload/delete_archive.py
+++ b/src/glacier_upload/delete_archive.py
@@ -2,7 +2,7 @@ import boto3
 import click
 
 
-@click.command
+@click.command()
 @click.option('-v', '--vault-name', required=True,
               help='The name of the vault')
 @click.option('-u', '--upload-id', required=True,

--- a/src/glacier_upload/list_uploads.py
+++ b/src/glacier_upload/list_uploads.py
@@ -4,7 +4,7 @@ import boto3
 import click
 
 
-@click.command
+@click.command()
 @click.option('-v', '--vault-name', required=True,
               help='The name of the vault')
 def list_all_uploads(vault_name):
@@ -21,7 +21,7 @@ def list_all_uploads(vault_name):
     click.echo(json.dumps(uploads_list, indent=2))
 
 
-@click.command
+@click.command()
 @click.option('-v', '--vault-name', required=True,
               help='The name of the vault')
 @click.option('-u', '--upload-id', required=True,


### PR DESCRIPTION
As reported in #8, the tools are not installable/usable. The patch fixes the following error:
```text
Traceback (most recent call last):
  File "/home/user/venv/bin/delete_glacier_archive", line 11, in <module>
    load_entry_point('glacier-upload', 'console_scripts', 'delete_glacier_archive')()
  File "/home/user/venv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/user/venv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/home/user/venv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/home/user/venv/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ImportError: No module named 'glacier_upload.delete_archive.delete_archive'; 'glacier_upload.delete_archive' is not a package
```