### PR TITLE
Add support for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
 
     classifiers=[
         'Development Status :: 4 - Beta',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
     ],

--- a/src/glacier_upload/upload.py
+++ b/src/glacier_upload/upload.py
@@ -106,7 +106,7 @@ def upload(vault_name, file_name, arc_desc, part_size, num_threads, upload_id):
             list_of_checksums.append(None)
 
         num_parts = len(job_list)
-        click.echo(f'File size is {file_size} bytes. Will upload in {num_parts} parts.')
+        click.echo('File size is {} bytes. Will upload in {} parts.'.format(file_size, num_parts))
     else:
         click.echo('Resuming upload...')
 


### PR DESCRIPTION
With a simple one-liner, the scripts are runnable under Python 3.5 (which is the default version on Ubuntu 16.04 LTS). Please feel free to close this PR if you don't like to maintain backwards compatibility with older versions.