### PR TITLE
Upload single file directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='glacier_upload',
 
-    version='1.0',
+    version='1.1',
 
     description='AWS Glacier upload utility',
 


### PR DESCRIPTION
In cases when only a single file should get uploaded, it is not necessary to create a tarball. With this patch, it's even possible to upload a complete partition (e.g. `/dev/sdb1`) without having to allocate additional memory or space.