### PR TITLE
Get archive in smaller chunks in case of large archives

### DIFF
--- a/src/glacier_upload/archives.py
+++ b/src/glacier_upload/archives.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import os
 
 import boto3
 import click
@@ -35,6 +36,11 @@ def init_archive_retrieval(vault_name, archive_id, description):
 
 
 def get_archive(vault_name, job_id, file_name):
+    # If file already exists, log warning and return
+    if os.path.isfile(file_name):
+        click.echo(f"File {file_name} already exists. Please delete it or provide another file name")
+        return
+
     glacier = boto3.client("glacier")
 
     click.echo("Checking job status...")
@@ -55,8 +61,32 @@ def get_archive(vault_name, job_id, file_name):
     elif response["contentType"] == "text/csv":
         click.echo(response["body"].read())
     else:
-        with open(file_name, "xb") as file:
-            file.write(response["body"].read())
+        download_archive(response, file_name)
+
+
+def download_archive(response, file_name):
+    response_stream, content_length = response["body"], int(
+        response['ResponseMetadata']['HTTPHeaders']['content-length'])
+    click.echo(f"Downloading archive to file {file_name}")
+    file = open(file_name, 'xb')
+    if content_length < 4096:
+        # Content length is < 4 KB, downloading it in one go
+        file.write(response_stream.read())
+    else:
+        # Download data in chunks of chunk_size
+        chunk_number = 1
+        chunk_size = 4096  # 4 KB
+        for chunk in response_stream.iter_chunks(chunk_size):
+            # Output percentage after every 25th iteration
+            file.write(chunk)
+            chunk_number += 1
+            download_percentage = (chunk_number * chunk_size) / content_length * 100
+            click.echo(
+                f"File download ... {download_percentage}% Byte position written ... {chunk_number * chunk_size}")
+
+        # Close the response stream and file
+        response_stream.close()
+        file.close()
 
 
 def delete_archive(vault_name, archive_id):

--- a/src/glacier_upload/archives.py
+++ b/src/glacier_upload/archives.py
@@ -79,10 +79,11 @@ def download_archive(response, file_name):
         for chunk in response_stream.iter_chunks(chunk_size):
             # Output percentage after every 25th iteration
             file.write(chunk)
-            chunk_number += 1
             download_percentage = (chunk_number * chunk_size) / content_length * 100
-            click.echo(
-                f"File download ... {download_percentage}% Byte position written ... {chunk_number * chunk_size}")
+            click.echo((f"File download ... {round(download_percentage, 2)}% " +
+                        f"Byte position written ... {chunk_number * chunk_size}"
+                        ))
+            chunk_number += 1
 
         # Close the response stream and file
         response_stream.close()

--- a/src/glacier_upload/archives.py
+++ b/src/glacier_upload/archives.py
@@ -74,18 +74,20 @@ def download_archive(response, file_name):
         file.write(response_stream.read())
     else:
         # Download data in chunks of chunk_size
-        chunk_number = 1
+        chunk_downloaded = 0
         chunk_size = 4096  # 4 KB
         for chunk in response_stream.iter_chunks(chunk_size):
-            # Output percentage after every 25th iteration
+            # iter_chunks returns bytes in chunk format by calling read internally for chunk_size
+            # https://github.com/boto/botocore/blob/51bcacab620bbb35c84157d61b9fed93f2a467f6/botocore/response.py#L125
             file.write(chunk)
-            download_percentage = (chunk_number * chunk_size) / content_length * 100
+            chunk_downloaded += len(chunk)
+            download_percentage = chunk_downloaded / content_length * 100
             click.echo((f"File download ... {round(download_percentage, 2)}% " +
-                        f"Byte position written ... {chunk_number * chunk_size}"
+                        f"Byte position written ... {chunk_downloaded}"
                         ))
-            chunk_number += 1
 
         # Close the response stream and file
+        click.echo(f"Total bytes downloaded {chunk_downloaded} of {content_length}")
         response_stream.close()
         file.close()
 

--- a/src/glacier_upload/archives.py
+++ b/src/glacier_upload/archives.py
@@ -86,10 +86,11 @@ def download_archive(response, file_name):
                         f"Byte position written ... {chunk_downloaded}"
                         ))
 
-        # Close the response stream and file
         click.echo(f"Total bytes downloaded {chunk_downloaded} of {content_length}")
-        response_stream.close()
-        file.close()
+
+    # Close the response stream and file
+    response_stream.close()
+    file.close()
 
 
 def delete_archive(vault_name, archive_id):

--- a/src/glacier_upload/upload.py
+++ b/src/glacier_upload/upload.py
@@ -54,7 +54,7 @@ def upload(vault_name, file_name, arc_desc, part_size, num_threads, upload_id):
     file_size = file_to_upload.seek(0, 2)
 
     if file_size < 4096:
-        click.echo("File size is less than 4 MB. Uploading in one request...")
+        click.echo("File size is less than 4 KB. Uploading in one request...")
 
         response = glacier.upload_archive(
             vaultName=vault_name, archiveDescription=arc_desc, body=file_to_upload


### PR DESCRIPTION
If the file can not fit in memory, `file.write(response["body"].read())` fails with MemoryError. `download_archive` divides the `response (botocore.response.StreamingBody)` into chunks and then writes into file. 