### PR TITLE
Format code using black

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ It is built to run on Python 3.5 and newer. Python 2 is not supported.
 
 ## Contributing
 
-Contributions and/or bug fixes are welcome! Just fork, make a topic branch, and submit a PR. Don't forget to add your name in CONTRIBUTORS.
+Contributions and/or bug fixes are welcome! Just fork, make a topic branch, format the code using [black](https://github.com/python/black) `--line-length=80` and submit a PR. Don't forget to add your name in CONTRIBUTORS.
 
 A good place to start is the TODO file.

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,36 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='glacier_upload',
-
-    version='1.2',
-
-    description='AWS Glacier upload utility',
-
+    name="glacier_upload",
+    version="1.2",
+    description="AWS Glacier upload utility",
     # The project's main homepage.
-    url='https://github.com/tbumi/glacier-upload',
-
+    url="https://github.com/tbumi/glacier-upload",
     # Author details
-    author='Trapsilo Bumi',
-    author_email='tbumi@thpd.io',
-
+    author="Trapsilo Bumi",
+    author_email="tbumi@thpd.io",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3 :: Only',
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
     ],
-
-    keywords='AWS Glacier upload multipart',
-
-    package_dir={'': 'src'},
-    packages=find_packages(where='src', exclude=['docs', 'tests']),
-
-    install_requires=['click', 'boto3'],
-
-    setup_requires=['pytest-runner'],
-
-    tests_require=['pytest'],
-
+    keywords="AWS Glacier upload multipart",
+    package_dir={"": "src"},
+    packages=find_packages(where="src", exclude=["docs", "tests"]),
+    install_requires=["click", "boto3"],
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
     entry_points={
-        'console_scripts': [
-            'glacier_upload=glacier_upload.upload:upload_command',
-            'list_all_glacier_uploads=glacier_upload.list_uploads:list_all_uploads_command',
-            'list_parts_in_upload=glacier_upload.list_uploads:list_parts_in_upload_command',
-            'init_archive_retrieval=glacier_upload.initiate_job:init_archive_retrieval_command',
-            'init_inventory_retrieval=glacier_upload.initiate_job:init_inventory_retrieval_command',
-            'get_glacier_job_output=glacier_upload.get_job_output:get_job_output_command',
-            'abort_glacier_upload=glacier_upload.abort_upload:abort_upload_command',
-            'delete_glacier_archive=glacier_upload.delete_archive:delete_archive_command'
-        ],
+        "console_scripts": [
+            "glacier_upload=glacier_upload.upload:upload_command",
+            "list_all_glacier_uploads=glacier_upload.list_uploads:list_all_uploads_command",
+            "list_parts_in_upload=glacier_upload.list_uploads:list_parts_in_upload_command",
+            "init_archive_retrieval=glacier_upload.initiate_job:init_archive_retrieval_command",
+            "init_inventory_retrieval=glacier_upload.initiate_job:init_inventory_retrieval_command",
+            "get_glacier_job_output=glacier_upload.get_job_output:get_job_output_command",
+            "abort_glacier_upload=glacier_upload.abort_upload:abort_upload_command",
+            "delete_glacier_archive=glacier_upload.delete_archive:delete_archive_command",
+        ]
     },
 )

--- a/src/glacier_upload/delete_archive.py
+++ b/src/glacier_upload/delete_archive.py
@@ -3,20 +3,19 @@ import click
 
 
 def delete_archive(vault_name, archive_id):
-    glacier = boto3.client('glacier')
+    glacier = boto3.client("glacier")
 
-    click.echo('Sending delete archive request...')
+    click.echo("Sending delete archive request...")
 
-    glacier.delete_archive(
-        vaultName=vault_name,
-        archiveId=archive_id)
+    glacier.delete_archive(vaultName=vault_name, archiveId=archive_id)
 
-    click.echo('Delete archive request sent.')
+    click.echo("Delete archive request sent.")
+
 
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault')
-@click.option('-a', '--archive-id', required=True,
-              help='ID of the archive to delete')
+@click.option("-v", "--vault-name", required=True, help="The name of the vault")
+@click.option(
+    "-a", "--archive-id", required=True, help="ID of the archive to delete"
+)
 def delete_archive_command(vault_name, archive_id):
     return delete_archive(vault_name, archive_id)

--- a/src/glacier_upload/get_job_output.py
+++ b/src/glacier_upload/get_job_output.py
@@ -5,40 +5,44 @@ import click
 
 
 def get_job_output(vault_name, job_id, file_name):
-    glacier = boto3.client('glacier')
+    glacier = boto3.client("glacier")
 
-    click.echo('Checking job status...')
-    response = glacier.describe_job(
-        vaultName=vault_name,
-        jobId=job_id)
+    click.echo("Checking job status...")
+    response = glacier.describe_job(vaultName=vault_name, jobId=job_id)
 
-    click.echo('Job status: {}'.format(response['StatusCode']))
+    click.echo("Job status: {}".format(response["StatusCode"]))
 
-    if not response['Completed']:
-        click.echo('Exiting.')
+    if not response["Completed"]:
+        click.echo("Exiting.")
         return
     else:
-        click.echo('Retrieving job data...')
-        response = glacier.get_job_output(
-            vaultName=vault_name,
-            jobId=job_id)
+        click.echo("Retrieving job data...")
+        response = glacier.get_job_output(vaultName=vault_name, jobId=job_id)
 
-        if response['contentType'] == 'application/json':
-            inventory_json = json.loads(response['body'].read().decode('utf-8'))
+        if response["contentType"] == "application/json":
+            inventory_json = json.loads(response["body"].read().decode("utf-8"))
             click.echo(json.dumps(inventory_json, indent=2))
-        elif response['contentType'] == 'text/csv':
-            click.echo(response['body'].read())
+        elif response["contentType"] == "text/csv":
+            click.echo(response["body"].read())
         else:
-            with open(file_name, 'xb') as file:
-                file.write(response['body'].read())
+            with open(file_name, "xb") as file:
+                file.write(response["body"].read())
+
 
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault to upload to')
-@click.option('-j', '--job-id', required=True,
-              help='Job ID')
-@click.option('-f', '--file-name', default='glacier_archive.tar.xz',
-              help='File name of archive to be saved, '
-                   'if the job is an archive-retrieval')
+@click.option(
+    "-v",
+    "--vault-name",
+    required=True,
+    help="The name of the vault to upload to",
+)
+@click.option("-j", "--job-id", required=True, help="Job ID")
+@click.option(
+    "-f",
+    "--file-name",
+    default="glacier_archive.tar.xz",
+    help="File name of archive to be saved, "
+    "if the job is an archive-retrieval",
+)
 def get_job_output_command(vault_name, job_id, file_name):
     return get_job_output(vault_name, job_id, file_name)

--- a/src/glacier_upload/initiate_job.py
+++ b/src/glacier_upload/initiate_job.py
@@ -3,60 +3,70 @@ import click
 
 
 def init_archive_retrieval(vault_name, archive_id, description):
-    glacier = boto3.client('glacier')
+    glacier = boto3.client("glacier")
 
-    job_params = {
-        'Type': 'archive-retrieval',
-        'ArchiveId': archive_id
-    }
+    job_params = {"Type": "archive-retrieval", "ArchiveId": archive_id}
     if description is not None:
-        job_params['Description'] = description
+        job_params["Description"] = description
 
-    print('Sending archive-retrieval initiation request...')
+    print("Sending archive-retrieval initiation request...")
 
     response = glacier.initiate_job(
-        vaultName=vault_name,
-        jobParameters=job_params)
+        vaultName=vault_name, jobParameters=job_params
+    )
 
-    print('Job initiation request recieved. Job ID: {}'.format(response['jobId']))
+    print(
+        "Job initiation request recieved. Job ID: {}".format(response["jobId"])
+    )
 
 
 def init_inventory_retrieval(vault_name, format, description):
-    glacier = boto3.client('glacier')
+    glacier = boto3.client("glacier")
 
-    job_params = {
-        'Type': 'inventory-retrieval',
-        'Format': format
-    }
+    job_params = {"Type": "inventory-retrieval", "Format": format}
     if description is not None:
-        job_params['Description'] = description
+        job_params["Description"] = description
 
-    print('Sending inventory-retrieval initiation request...')
+    print("Sending inventory-retrieval initiation request...")
 
     response = glacier.initiate_job(
-        vaultName=vault_name,
-        jobParameters=job_params)
+        vaultName=vault_name, jobParameters=job_params
+    )
 
-    print('Job initiation request recieved. Job ID: {}'.format(response['jobId']))
+    print(
+        "Job initiation request recieved. Job ID: {}".format(response["jobId"])
+    )
 
 
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault to upload to')
-@click.option('-a', '--archive-id', required=True,
-              help='ID of the archive to retrieve')
-@click.option('-d', '--description',
-              help='Description of this job (optional)')
+@click.option(
+    "-v",
+    "--vault-name",
+    required=True,
+    help="The name of the vault to upload to",
+)
+@click.option(
+    "-a", "--archive-id", required=True, help="ID of the archive to retrieve"
+)
+@click.option("-d", "--description", help="Description of this job (optional)")
 def init_archive_retrieval_command(vault_name, archive_id, description):
     return init_archive_retrieval_command(vault_name, archive_id, description)
 
 
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault to upload to')
-@click.option('-f', '--format', default='JSON', type=click.Choice(['CSV', 'JSON']),
-              help='Format to request from glacier')
-@click.option('-d', '--description',
-              help='Description of this job (optional)')
+@click.option(
+    "-v",
+    "--vault-name",
+    required=True,
+    help="The name of the vault to upload to",
+)
+@click.option(
+    "-f",
+    "--format",
+    default="JSON",
+    type=click.Choice(["CSV", "JSON"]),
+    help="Format to request from glacier",
+)
+@click.option("-d", "--description", help="Description of this job (optional)")
 def init_inventory_retrieval_command(vault_name, format, description):
     return init_inventory_retrieval(vault_name, format, description)

--- a/src/glacier_upload/list_uploads.py
+++ b/src/glacier_upload/list_uploads.py
@@ -5,43 +5,45 @@ import click
 
 
 def list_all_uploads(vault_name):
-    glacier = boto3.client('glacier')
-    click.echo('Listing all multipart uploads...')
+    glacier = boto3.client("glacier")
+    click.echo("Listing all multipart uploads...")
 
     response = glacier.list_multipart_uploads(vaultName=vault_name)
-    uploads_list = response['UploadsList']
-    while 'Marker' in response:
+    uploads_list = response["UploadsList"]
+    while "Marker" in response:
         response = glacier.list_multipart_uploads(
-            vaultName=vault_name, marker=response['Marker'])
-        uploads_list.extend(response['UploadsList'])
+            vaultName=vault_name, marker=response["Marker"]
+        )
+        uploads_list.extend(response["UploadsList"])
 
     click.echo(json.dumps(uploads_list, indent=2))
 
 
 def list_parts_in_upload(vault_name, upload_id):
-    glacier = boto3.client('glacier')
-    click.echo('Listing parts in one multipart upload...')
+    glacier = boto3.client("glacier")
+    click.echo("Listing parts in one multipart upload...")
 
     response = glacier.list_parts(vaultName=vault_name, uploadId=upload_id)
-    parts_list = response['Parts']
-    while 'Marker' in response:
+    parts_list = response["Parts"]
+    while "Marker" in response:
         response = glacier.list_parts(
-            vaultName=vault_name, marker=response['Marker'])
-        parts_list.extend(response['Parts'])
+            vaultName=vault_name, marker=response["Marker"]
+        )
+        parts_list.extend(response["Parts"])
 
     click.echo(json.dumps(parts_list, indent=2))
 
+
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault')
+@click.option("-v", "--vault-name", required=True, help="The name of the vault")
 def list_all_uploads_command(vault_name):
     return list_all_uploads(vault_name)
 
+
 @click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault')
-@click.option('-u', '--upload-id', required=True,
-              help='ID of upload to list parts')
+@click.option("-v", "--vault-name", required=True, help="The name of the vault")
+@click.option(
+    "-u", "--upload-id", required=True, help="ID of upload to list parts"
+)
 def list_parts_in_upload_command(vault_name, upload_id):
     return list_parts_in_upload(vault_name, upload_id)
-

--- a/src/glacier_upload/manual_abort_upload.py
+++ b/src/glacier_upload/manual_abort_upload.py
@@ -3,19 +3,16 @@ import click
 
 
 def abort_upload(vault_name, upload_id):
-    glacier = boto3.client('glacier')
+    glacier = boto3.client("glacier")
 
-    click.echo('Aborting upload...')
-    glacier.abort_multipart_upload(
-        vaultName=vault_name,
-        uploadId=upload_id
-    )
+    click.echo("Aborting upload...")
+    glacier.abort_multipart_upload(vaultName=vault_name, uploadId=upload_id)
 
-    click.echo('Aborted.')
+    click.echo("Aborted.")
+
 
 @click.command()
-@click.argument('vault_name')
-@click.argument('upload_id')
+@click.argument("vault_name")
+@click.argument("upload_id")
 def abort_upload_command(vault_name, upload_id):
     return abort_upload(vault_name, upload_id)
-

--- a/src/glacier_upload/upload.py
+++ b/src/glacier_upload/upload.py
@@ -32,45 +32,49 @@ MAX_ATTEMPTS = 10
 fileblock = threading.Lock()
 
 
-def upload(vault_name, file_name, region, arc_desc, part_size, num_threads, upload_id):
-    glacier = boto3.client('glacier', region)
+def upload(
+    vault_name, file_name, region, arc_desc, part_size, num_threads, upload_id
+):
+    glacier = boto3.client("glacier", region)
 
     if not math.log2(part_size).is_integer():
-        raise ValueError('part-size must be a power of 2')
+        raise ValueError("part-size must be a power of 2")
     if part_size < 1 or part_size > 4096:
-        raise ValueError('part-size must be more than 1 MB '
-                         'and less than 4096 MB')
+        raise ValueError(
+            "part-size must be more than 1 MB " "and less than 4096 MB"
+        )
 
-    click.echo('Reading file...')
+    click.echo("Reading file...")
     if len(file_name) > 1 or os.path.isdir(file_name[0]):
-        click.echo('Tarring file...')
+        click.echo("Tarring file...")
         file_to_upload = tempfile.TemporaryFile()
-        tar = tarfile.open(fileobj=file_to_upload, mode='w:xz')
+        tar = tarfile.open(fileobj=file_to_upload, mode="w:xz")
         for filename in file_name:
             tar.add(filename)
         tar.close()
-        click.echo('File tarred.')
+        click.echo("File tarred.")
     else:
-        file_to_upload = open(file_name[0], mode='rb')
-        click.echo('Opened single file.')
+        file_to_upload = open(file_name[0], mode="rb")
+        click.echo("Opened single file.")
 
     part_size = part_size * 1024 * 1024
 
     file_size = file_to_upload.seek(0, 2)
 
     if file_size < 4096:
-        click.echo('File size is less than 4 MB. Uploading in one request...')
+        click.echo("File size is less than 4 MB. Uploading in one request...")
 
         response = glacier.upload_archive(
             vaultName=vault_name,
             archiveDescription=arc_desc,
-            body=file_to_upload)
+            body=file_to_upload,
+        )
 
-        click.echo('Uploaded.')
-        click.echo('Glacier tree hash: %s' % response['checksum'])
-        click.echo('Location: %s' % response['location'])
-        click.echo('Archive ID: %s' % response['archiveId'])
-        click.echo('Done.')
+        click.echo("Uploaded.")
+        click.echo("Glacier tree hash: %s" % response["checksum"])
+        click.echo("Location: %s" % response["location"])
+        click.echo("Archive ID: %s" % response["archiveId"])
+        click.echo("Done.")
         file_to_upload.close()
         return
 
@@ -78,64 +82,79 @@ def upload(vault_name, file_name, region, arc_desc, part_size, num_threads, uplo
     list_of_checksums = []
 
     if upload_id is None:
-        click.echo('Initiating multipart upload...')
+        click.echo("Initiating multipart upload...")
         response = glacier.initiate_multipart_upload(
             vaultName=vault_name,
             archiveDescription=arc_desc,
-            partSize=str(part_size)
+            partSize=str(part_size),
         )
-        upload_id = response['uploadId']
+        upload_id = response["uploadId"]
 
         for byte_pos in range(0, file_size, part_size):
             job_list.append(byte_pos)
             list_of_checksums.append(None)
 
         num_parts = len(job_list)
-        click.echo('File size is {} bytes. Will upload in {} parts.'.format(file_size, num_parts))
-    else:
-        click.echo('Resuming upload...')
-
-        click.echo('Fetching already uploaded parts...')
-        response = glacier.list_parts(
-            vaultName=vault_name,
-            uploadId=upload_id
+        click.echo(
+            "File size is {} bytes. Will upload in {} parts.".format(
+                file_size, num_parts
+            )
         )
-        parts = response['Parts']
-        part_size = response['PartSizeInBytes']
-        while 'Marker' in response:
-            click.echo('Getting more parts...')
+    else:
+        click.echo("Resuming upload...")
+
+        click.echo("Fetching already uploaded parts...")
+        response = glacier.list_parts(vaultName=vault_name, uploadId=upload_id)
+        parts = response["Parts"]
+        part_size = response["PartSizeInBytes"]
+        while "Marker" in response:
+            click.echo("Getting more parts...")
             response = glacier.list_parts(
                 vaultName=vault_name,
                 uploadId=upload_id,
-                marker=response['Marker']
+                marker=response["Marker"],
             )
-            parts.extend(response['Parts'])
+            parts.extend(response["Parts"])
 
         for byte_pos in range(0, file_size, part_size):
             job_list.append(byte_pos)
             list_of_checksums.append(None)
 
         num_parts = len(job_list)
-        with click.progressbar(parts, label='Verifying uploaded parts') as bar:
+        with click.progressbar(parts, label="Verifying uploaded parts") as bar:
             for part_data in bar:
-                byte_start = int(part_data['RangeInBytes'].partition('-')[0])
+                byte_start = int(part_data["RangeInBytes"].partition("-")[0])
                 file_to_upload.seek(byte_start)
                 part = file_to_upload.read(part_size)
                 checksum = calculate_tree_hash(part, part_size)
 
-                if checksum == part_data['SHA256TreeHash']:
+                if checksum == part_data["SHA256TreeHash"]:
                     job_list.remove(byte_start)
                     part_num = byte_start // part_size
                     list_of_checksums[part_num] = checksum
 
-    click.echo('Spawning threads...')
+    click.echo("Spawning threads...")
     with concurrent.futures.ThreadPoolExecutor(
-            max_workers=num_threads) as executor:
-        futures_list = {executor.submit(
-            upload_part, job, vault_name, upload_id, part_size, file_to_upload,
-            file_size, num_parts, glacier): job // part_size for job in job_list}
+        max_workers=num_threads
+    ) as executor:
+        futures_list = {
+            executor.submit(
+                upload_part,
+                job,
+                vault_name,
+                upload_id,
+                part_size,
+                file_to_upload,
+                file_size,
+                num_parts,
+                glacier,
+            ): job
+            // part_size
+            for job in job_list
+        }
         done, not_done = concurrent.futures.wait(
-            futures_list, return_when=concurrent.futures.FIRST_EXCEPTION)
+            futures_list, return_when=concurrent.futures.FIRST_EXCEPTION
+        )
         if len(not_done) > 0:
             # an exception occured
             for future in not_done:
@@ -143,9 +162,9 @@ def upload(vault_name, file_name, region, arc_desc, part_size, num_threads, uplo
             for future in done:
                 e = future.exception()
                 if e is not None:
-                    click.echo('Exception occured: %r' % e)
-            click.echo('Upload not aborted. Upload id: %s' % upload_id)
-            click.echo('Exiting.')
+                    click.echo("Exception occured: %r" % e)
+            click.echo("Upload not aborted. Upload id: %s" % upload_id)
+            click.echo("Exiting.")
             file_to_upload.close()
             sys.exit(1)
         else:
@@ -155,84 +174,137 @@ def upload(vault_name, file_name, region, arc_desc, part_size, num_threads, uplo
                 list_of_checksums[job_index] = future.result()
 
     if len(list_of_checksums) != num_parts:
-        click.echo('List of checksums incomplete. Recalculating...')
+        click.echo("List of checksums incomplete. Recalculating...")
         list_of_checksums = []
         for byte_pos in range(0, file_size, part_size):
             part_num = int(byte_pos / part_size)
-            click.echo('Checksum %s of %s...' % (part_num + 1, num_parts))
+            click.echo("Checksum %s of %s..." % (part_num + 1, num_parts))
             file_to_upload.seek(byte_pos)
             part = file_to_upload.read(part_size)
             list_of_checksums.append(calculate_tree_hash(part, part_size))
 
     total_tree_hash = calculate_total_tree_hash(list_of_checksums)
 
-    click.echo('Completing multipart upload...')
+    click.echo("Completing multipart upload...")
     response = glacier.complete_multipart_upload(
-        vaultName=vault_name, uploadId=upload_id,
-        archiveSize=str(file_size), checksum=total_tree_hash)
-    click.echo('Upload successful.')
-    click.echo('Calculated total tree hash: %s' % total_tree_hash)
-    click.echo('Glacier total tree hash: %s' % response['checksum'])
-    click.echo('Location: %s' % response['location'])
-    click.echo('Archive ID: %s' % response['archiveId'])
-    click.echo('Done.')
+        vaultName=vault_name,
+        uploadId=upload_id,
+        archiveSize=str(file_size),
+        checksum=total_tree_hash,
+    )
+    click.echo("Upload successful.")
+    click.echo("Calculated total tree hash: %s" % total_tree_hash)
+    click.echo("Glacier total tree hash: %s" % response["checksum"])
+    click.echo("Location: %s" % response["location"])
+    click.echo("Archive ID: %s" % response["archiveId"])
+    click.echo("Done.")
     file_to_upload.close()
 
-@click.command()
-@click.option('-v', '--vault-name', required=True,
-              help='The name of the vault to upload to')
-@click.option('-f', '--file-name', required=True, multiple=True,
-              help='The file or directory name on your local '
-              'filesystem to upload')
-@click.option('-r', '--region',
-              help='The name of the region to upload to')
-@click.option('-d', '--arc-desc', default='',
-              metavar='ARCHIVE_DESCRIPTION',
-              help='The archive description to help identify archives later')
-@click.option('-p', '--part-size', type=int, default=8,
-              help='The part size for multipart upload, in '
-              'megabytes (e.g. 1, 2, 4, 8) default: 8')
-@click.option('-t', '--num-threads', type=int, default=5,
-              help='The amount of concurrent threads (default: 5)')
-@click.option('-u', '--upload-id',
-              help='Optional upload id, if provided then will '
-              'resume upload.')
-def upload_command(vault_name, file_name, region, arc_desc, part_size, num_threads, upload_id):
-    return upload(vault_name, file_name, region, arc_desc, part_size, num_threads, upload_id)
 
-def upload_part(byte_pos, vault_name, upload_id, part_size, fileobj, file_size,
-                num_parts, glacier):
+@click.command()
+@click.option(
+    "-v",
+    "--vault-name",
+    required=True,
+    help="The name of the vault to upload to",
+)
+@click.option(
+    "-f",
+    "--file-name",
+    required=True,
+    multiple=True,
+    help="The file or directory name on your local " "filesystem to upload",
+)
+@click.option("-r", "--region", help="The name of the region to upload to")
+@click.option(
+    "-d",
+    "--arc-desc",
+    default="",
+    metavar="ARCHIVE_DESCRIPTION",
+    help="The archive description to help identify archives later",
+)
+@click.option(
+    "-p",
+    "--part-size",
+    type=int,
+    default=8,
+    help="The part size for multipart upload, in "
+    "megabytes (e.g. 1, 2, 4, 8) default: 8",
+)
+@click.option(
+    "-t",
+    "--num-threads",
+    type=int,
+    default=5,
+    help="The amount of concurrent threads (default: 5)",
+)
+@click.option(
+    "-u",
+    "--upload-id",
+    help="Optional upload id, if provided then will " "resume upload.",
+)
+def upload_command(
+    vault_name, file_name, region, arc_desc, part_size, num_threads, upload_id
+):
+    return upload(
+        vault_name,
+        file_name,
+        region,
+        arc_desc,
+        part_size,
+        num_threads,
+        upload_id,
+    )
+
+
+def upload_part(
+    byte_pos,
+    vault_name,
+    upload_id,
+    part_size,
+    fileobj,
+    file_size,
+    num_parts,
+    glacier,
+):
     fileblock.acquire()
     fileobj.seek(byte_pos)
     part = fileobj.read(part_size)
     fileblock.release()
 
-    range_header = 'bytes {}-{}/{}'.format(
-        byte_pos, byte_pos + len(part) - 1, file_size)
+    range_header = "bytes {}-{}/{}".format(
+        byte_pos, byte_pos + len(part) - 1, file_size
+    )
     part_num = byte_pos // part_size
     percentage = part_num / num_parts
 
-    click.echo('Uploading part {0} of {1}... ({2:.2%})'.format(
-        part_num + 1, num_parts, percentage))
+    click.echo(
+        "Uploading part {0} of {1}... ({2:.2%})".format(
+            part_num + 1, num_parts, percentage
+        )
+    )
 
     for i in range(MAX_ATTEMPTS):
         try:
             response = glacier.upload_multipart_part(
-                vaultName=vault_name, uploadId=upload_id,
-                range=range_header, body=part)
+                vaultName=vault_name,
+                uploadId=upload_id,
+                range=range_header,
+                body=part,
+            )
             checksum = calculate_tree_hash(part, part_size)
-            if checksum != response['checksum']:
-                click.echo('Checksums do not match. Will try again.')
+            if checksum != response["checksum"]:
+                click.echo("Checksums do not match. Will try again.")
                 continue
 
             # if everything worked, then we can break
             break
         except:
-            click.echo('Upload error:', sys.exc_info()[0])
-            click.echo('Trying again. Part {0}'.format(part_num + 1))
+            click.echo("Upload error:", sys.exc_info()[0])
+            click.echo("Trying again. Part {0}".format(part_num + 1))
     else:
-        click.echo('After multiple attempts, still failed to upload part')
-        click.echo('Exiting.')
+        click.echo("After multiple attempts, still failed to upload part")
+        click.echo("Exiting.")
         sys.exit(1)
 
     del part
@@ -244,7 +316,7 @@ def calculate_tree_hash(part, part_size):
     upper_bound = min(len(part), part_size)
     step = 1024 * 1024  # 1 MB
     for chunk_pos in range(0, upper_bound, step):
-        chunk = part[chunk_pos:chunk_pos+step]
+        chunk = part[chunk_pos : chunk_pos + step]
         checksums.append(hashlib.sha256(chunk).hexdigest())
         del chunk
     return calculate_total_tree_hash(checksums)
@@ -265,5 +337,5 @@ def calculate_total_tree_hash(list_of_checksums):
     return tree[0]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     upload()


### PR DESCRIPTION
This pull request formats the code using [black](https://github.com/python/black) `--line-length=80` and adds to documentation that `black --line-length=80` should be used to format code.

I see you have already adopted black in `feature/version2` branch using `--line-length=80`  but I propose that this formatting is merged now since it might make merging with branch `feature/version2` easier and will enable future contributions to be more easily formatted.