### PR TITLE
Fix crash during upload if connection reset

### DIFF
--- a/src/glacier_upload/upload.py
+++ b/src/glacier_upload/upload.py
@@ -299,8 +299,8 @@ def upload_part(
 
             # if everything worked, then we can break
             break
-        except:
-            click.echo("Upload error:", sys.exc_info()[0])
+        except Exception as e:
+            click.echo("Upload error occured: %r" % e)
             click.echo("Trying again. Part {0}".format(part_num + 1))
     else:
         click.echo("After multiple attempts, still failed to upload part")


### PR DESCRIPTION
When any exception occurs during upload, it tries to print the exception to `click.echo`. However, the second argument of `click.echo` is a file that you want to write to. The exception was passed instead, which is not a file, which is was caused the `type object 'ConnectionClosedError' has no attribute 'write')`. As a fix, we now print the exception using normal string formatting.

Closes #23